### PR TITLE
[ks50team01-bit] 유저 페이지 여행 계획 상세 조회 작성 중

### DIFF
--- a/src/main/java/ksmart/ks50team01/user/breadcrumb/Breadcrumb.java
+++ b/src/main/java/ksmart/ks50team01/user/breadcrumb/Breadcrumb.java
@@ -22,12 +22,18 @@ public class Breadcrumb {
 		pageNames.put("contact", "Contact Us");
 		pageNames.put("trip", "여행 계획");
 		pageNames.put("plan", "여행 계획 작성");
+		pageNames.put("tourInfo", "여행지 정보 조회");
+		pageNames.put("schedule", "여행 계획 상세 조회");
+		pageNames.put("list", "내 여행 계획 목록");
+		pageNames.put("detail", "여행 계획 작성");
+		pageNames.put("board", "여행 계획 공유 게시판");
 		pageNames.put("shareBoard", "여행 계획 공유");
 		pageNames.put("allRanking", "여행 추천");
 		pageNames.put("rankingList", "플랫폼 추천");
 		pageNames.put("userRankingList", "회원추천");
 		pageNames.put("planRankingList", "여행계획 추천");
-		
+
+
 		// 필요한 만큼 추가
 		return pageNames;
 	}

--- a/src/main/java/ksmart/ks50team01/user/config/WebConfig.java
+++ b/src/main/java/ksmart/ks50team01/user/config/WebConfig.java
@@ -4,8 +4,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import ksmart.ks50team01.user.interceptor.AuthenticationInterceptor;
 import ksmart.ks50team01.user.interceptor.BreadcrumbInterceptor;
 import ksmart.ks50team01.user.interceptor.IndexInterceptor;
+import ksmart.ks50team01.user.interceptor.RedirectAttributesInterceptor;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -15,14 +17,31 @@ public class WebConfig implements WebMvcConfigurer {
 	private final BreadcrumbInterceptor breadcrumbInterceptor;
 	private final IndexInterceptor indexInterceptor;
 
+	private final RedirectAttributesInterceptor redirectAttributesInterceptor;
+	private final AuthenticationInterceptor authenticationInterceptor;
+
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
+		// 동적으로 브레드크럼을 생성하도록 등록
 		registry.addInterceptor(breadcrumbInterceptor)
 				.addPathPatterns("/**")
 				.excludePathPatterns("/js/**")
 				.excludePathPatterns("/css/**")
 				.excludePathPatterns("/favicon.ico");
 
+		// 첫 페이지에 배너를 제외하도록 등록
 		registry.addInterceptor(indexInterceptor);
+
+		// 로그인 상태일때만 여행 계획 메뉴 접근이 가능하도록 조정
+		registry.addInterceptor(authenticationInterceptor)
+			.addPathPatterns("/trip/**")
+			.excludePathPatterns(
+				"/trip/login",
+				"/trip/register",
+				"/trip/logout",
+				"/trip", "/trip/",
+				"/trip/tourInfo",
+				"/trip/board"
+			);
 	}
 }

--- a/src/main/java/ksmart/ks50team01/user/exception/UserExceptionController.java
+++ b/src/main/java/ksmart/ks50team01/user/exception/UserExceptionController.java
@@ -1,0 +1,23 @@
+package ksmart.ks50team01.user.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@ControllerAdvice(basePackages = "ksmart.ks50team01.user.trip")
+public class UserExceptionController {
+
+	@ExceptionHandler(Exception.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	public String handleOtherExceptions(Exception ex, HttpServletRequest request, Model model) {
+		// 현재 요청의 URL을 가져와서 모델에 추가
+		String url = request.getRequestURI();
+		model.addAttribute("exception", ex);
+		model.addAttribute("url", url);
+		return "user/error/error"; // 에러 페이지로 이동 혹은 다른 처리
+	}
+}

--- a/src/main/java/ksmart/ks50team01/user/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/ksmart/ks50team01/user/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,32 @@
+package ksmart.ks50team01.user.interceptor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.FlashMap;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.support.SessionFlashMapManager;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+@Component
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+		HttpSession session = request.getSession();
+		if (session.getAttribute("loginId") == null) {
+			// Flash attribute를 사용하여 메시지 설정
+			SessionFlashMapManager flashMapManager = new SessionFlashMapManager();
+			FlashMap flashMap = new FlashMap();
+			flashMap.put("message", "로그인이 필요합니다.");
+			flashMapManager.saveOutputFlashMap(flashMap, request, response);
+			response.sendRedirect("/trip");
+			return false;
+
+		}
+		return true;
+	}
+}

--- a/src/main/java/ksmart/ks50team01/user/interceptor/RedirectAttributesInterceptor.java
+++ b/src/main/java/ksmart/ks50team01/user/interceptor/RedirectAttributesInterceptor.java
@@ -1,0 +1,29 @@
+package ksmart.ks50team01.user.interceptor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.context.request.WebRequestInterceptor;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+@Component
+public class RedirectAttributesInterceptor implements WebRequestInterceptor {
+
+	@Override
+	public void preHandle(WebRequest request) {
+		RedirectAttributes redirectAttributes = new RedirectAttributesModelMap();
+		request.setAttribute("REDIRECT_ATTRIBUTES",redirectAttributes, RequestAttributes.SCOPE_REQUEST);
+	}
+
+	@Override
+	public void postHandle(WebRequest request, ModelMap model) throws Exception {
+
+	}
+
+	@Override
+	public void afterCompletion(WebRequest request, Exception ex) throws Exception {
+
+	}
+}

--- a/src/main/java/ksmart/ks50team01/user/trip/dto/UTripDetailOption.java
+++ b/src/main/java/ksmart/ks50team01/user/trip/dto/UTripDetailOption.java
@@ -1,0 +1,13 @@
+package ksmart.ks50team01.user.trip.dto;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class UTripDetailOption {
+	private String planUUID;
+
+
+	private List<UDayInfo> days;
+}

--- a/src/main/java/ksmart/ks50team01/user/trip/dto/UTripOption.java
+++ b/src/main/java/ksmart/ks50team01/user/trip/dto/UTripOption.java
@@ -2,10 +2,13 @@ package ksmart.ks50team01.user.trip.dto;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
+import ksmart.ks50team01.platform.trip.dto.PTourDetail;
 import lombok.Data;
 
 @Data
@@ -45,6 +48,12 @@ public class UTripOption {
 
     private String tripDuration;
 
+    // TRIP_PLAN_ITEMS_NEW 테이블 정보
+    private List<UTripPlanItem> tripItems;
+
+    // TOUR_DETAIL_FROM_API 테이블 정보
+    private List<PTourDetail> tourDetails;
+
     // description 필드를 구성하는 메서드 추가
     public String getDescription() {
         return String.format("출발 날짜: %s, 도착 날짜: %s, 상태: %s",
@@ -52,4 +61,19 @@ public class UTripOption {
             endDate != null ? endDate.toString() : "미정",
             inProgress != null ? inProgress : "작성중");
     }
+
+    private List<DayPlan> dayPlans = new ArrayList<>();
+
+    @Data
+    public static class DayPlan {
+        private Integer dayNumber;
+        private LocalDate date;
+        private List<UTripPlanItem> items = new ArrayList<>();
+
+        public void setStartDateAndDayNumber(LocalDate startDate, Integer dayNumber) {
+            this.dayNumber = dayNumber;
+            this.date = startDate.plusDays(dayNumber - 1);
+        }
+    }
+
 }

--- a/src/main/java/ksmart/ks50team01/user/trip/dto/UTripPlanItem.java
+++ b/src/main/java/ksmart/ks50team01/user/trip/dto/UTripPlanItem.java
@@ -1,0 +1,20 @@
+package ksmart.ks50team01.user.trip.dto;
+
+import java.time.LocalDate;
+
+import ksmart.ks50team01.platform.trip.dto.PTourDetail;
+import lombok.Data;
+
+@Data
+public class UTripPlanItem {
+	private int itemId;
+	private String planUUID;
+	private String dayNumber;
+	private String contentId;
+	private Integer orderNumber;
+	private LocalDate date;
+	private String regDate;
+
+	// contentId에 일치하는 필드 가져오도록
+	private PTourDetail tourDetail;
+}

--- a/src/main/java/ksmart/ks50team01/user/trip/mapper/UTripPlanMapper.java
+++ b/src/main/java/ksmart/ks50team01/user/trip/mapper/UTripPlanMapper.java
@@ -4,9 +4,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
+import ksmart.ks50team01.platform.trip.dto.PTourDetail;
 import ksmart.ks50team01.user.member.login.dto.Login;
 import ksmart.ks50team01.user.trip.dto.UTripOption;
+import ksmart.ks50team01.user.trip.dto.UTripPlanItem;
 
 @Mapper
 public interface UTripPlanMapper {
@@ -60,4 +63,19 @@ public interface UTripPlanMapper {
 
 	// Tour API에서 DB에 저장한 여행 상세 정보 목록 조
 	List<Map<String, Object>> getTourDataList();
+
+	boolean existsByPlanUUID(String planUUID);
+
+	int deleteDetailInfo(String planUUID);
+
+	int insertDetailInfo(@Param("planUUID") String planUUID,
+		@Param("dayNumber") int dayNumber,
+		@Param("contentId") String contentId,
+		@Param("order") int order);
+
+	UTripOption getTripPlanByUUID(String planUUID);
+
+	List<UTripPlanItem> getTripItemsByUUID(String planUUID);
+
+	List<PTourDetail> getPTourDetailByContentId(List<String> contentIds);
 }

--- a/src/main/java/ksmart/ks50team01/user/trip/service/UTripPlanService.java
+++ b/src/main/java/ksmart/ks50team01/user/trip/service/UTripPlanService.java
@@ -3,10 +3,14 @@ package ksmart.ks50team01.user.trip.service;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.coyote.BadRequestException;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import ksmart.ks50team01.user.member.login.dto.Login;
 import ksmart.ks50team01.user.trip.dto.UDayInfo;
+import ksmart.ks50team01.user.trip.dto.UDistanceRequest;
+import ksmart.ks50team01.user.trip.dto.UTripDetailOption;
 import ksmart.ks50team01.user.trip.dto.UTripOption;
 
 public interface UTripPlanService {
@@ -45,4 +49,10 @@ public interface UTripPlanService {
 
 	// Tour API에서 DB로 저장한 상세 정보 목록 조회
 	List<Map<String, Object>> getTourDataList();
+
+	// 여행 계획 상세 정보 저장
+	int saveTripDetailInfo(UTripDetailOption uTripDetailOption) throws BadRequestException;
+
+	// UUID와 일치하는 여행 상세 정보 조회
+	UTripOption getTripOptionByUUID(String planUUID);
 }

--- a/src/main/java/ksmart/ks50team01/user/trip/service/UTripPlanServiceImpl.java
+++ b/src/main/java/ksmart/ks50team01/user/trip/service/UTripPlanServiceImpl.java
@@ -3,16 +3,21 @@ package ksmart.ks50team01.user.trip.service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import org.apache.coyote.BadRequestException;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,12 +27,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import ksmart.ks50team01.platform.trip.dto.PTourDetail;
 import ksmart.ks50team01.user.member.login.dto.Login;
 import ksmart.ks50team01.user.trip.dto.TMapApiResponse;
 import ksmart.ks50team01.user.trip.dto.UDayDistanceResult;
 import ksmart.ks50team01.user.trip.dto.UDayInfo;
 import ksmart.ks50team01.user.trip.dto.ULocationDistanceInfo;
+import ksmart.ks50team01.user.trip.dto.UTripDetailOption;
 import ksmart.ks50team01.user.trip.dto.UTripOption;
+import ksmart.ks50team01.user.trip.dto.UTripPlanItem;
 import ksmart.ks50team01.user.trip.enums.UTripContent;
 import ksmart.ks50team01.user.trip.mapper.UTripPlanMapper;
 import lombok.RequiredArgsConstructor;
@@ -224,7 +232,6 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 			plan.setDescription(plan.getDescription());
 			calculateTripDuration(plan);
 			calculateAndSetDayDiff(plan);
-
 		});
 
 		return plans;
@@ -254,6 +261,108 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 	@Override
 	public List<Map<String, Object>> getTourDataList() {
 		return uTripPlanMapper.getTourDataList();
+	}
+
+	/**
+	 * 여행 계획 상세 정보 저장 메서드
+	 * @param uTripDetailOption 여행 계획 상세 정보 DTO
+	 */
+	@Override
+	public int saveTripDetailInfo(UTripDetailOption uTripDetailOption) throws BadRequestException {
+		String planUUID = uTripDetailOption.getPlanUUID();
+		List<UDayInfo> dayInfos = uTripDetailOption.getDays();
+
+		// 처리된 쿼리 확인
+		int totalRowsAffected = 0;
+
+		// 예외 처리 예시: 잘못된 요청 시 BadRequestException 던지기
+		if (planUUID == null || planUUID.isEmpty()) {
+			throw new BadRequestException("planUUID는 필수입니다.");
+		}
+
+		// planUUID가 존재하는지 확인
+		if (uTripPlanMapper.existsByPlanUUID(planUUID)) {
+			// 기존 데이터 삭제
+			totalRowsAffected += uTripPlanMapper.deleteDetailInfo(planUUID);
+		}
+
+		// 새로운 데이터 저장
+		for (UDayInfo dayInfo : dayInfos) {
+			int dayNumber = dayInfo.getDay();
+			List<ULocationDistanceInfo> locations = dayInfo.getLocations();
+
+			for (ULocationDistanceInfo location : locations) {
+				String contentId = location.getContentId();
+				int order = location.getOrder();
+
+				totalRowsAffected += uTripPlanMapper.insertDetailInfo(planUUID, dayNumber, contentId, order);
+			}
+		}
+		return totalRowsAffected;
+	}
+
+	/**
+	 * UUID와 일치하는 여행 계획 상세 정보 조회 메서드
+	 * @param planUUID 여행 계획 UUID
+	 * @return
+	 */
+	@Override
+	public UTripOption getTripOptionByUUID(String planUUID) {
+		UTripOption tripOption = uTripPlanMapper.getTripPlanByUUID(planUUID);
+		if (tripOption != null) {
+			// TRIP_PLAN_ITEMS_NEW 테이블에서 일정 항목 조회
+			List<UTripPlanItem> tripItems = uTripPlanMapper.getTripItemsByUUID(planUUID);
+			log.info("tripItems: {}", tripItems);
+
+			// TOUR_DETAIL_FROM_API 테이블에서 관련 정보 조회
+			List<String> contentIds = tripItems.stream()
+				.map(UTripPlanItem::getContentId)
+				.toList();
+			List<PTourDetail> tourDetails = uTripPlanMapper.getPTourDetailByContentId(contentIds);
+
+			// contentId를 키로 하는 Map 생성
+			Map<String, PTourDetail> tourDetailMap = tourDetails.stream()
+				.collect(Collectors.toMap(PTourDetail::getContentId, Function.identity()));
+
+			addTripItemsForDates(tripOption, tripItems, tourDetailMap);
+			tripOption.setTourDetails(tourDetails);
+
+			return tripOption;
+		}
+		return null;
+	}
+
+
+	private void addTripItemsForDates(UTripOption tripOption, List<UTripPlanItem> tripItems, Map<String, PTourDetail> tourDetailMap) {
+		if (tripOption.getStartDate() == null || tripItems == null || tripItems.isEmpty()) {
+			throw new IllegalArgumentException("Start date and trip items must be provided.");
+		}
+
+		tripOption.getDayPlans().clear();
+
+		// 각 날짜별 DayPlan 생성
+		for (UTripPlanItem item : tripItems) {
+			int dayNumber = Integer.parseInt(item.getDayNumber());
+			UTripOption.DayPlan dayPlan = tripOption.getDayPlans().stream()
+				.filter(plan -> plan.getDayNumber() == dayNumber)
+				.findFirst()
+				.orElseGet(() -> {
+					UTripOption.DayPlan newDayPlan = new UTripOption.DayPlan();
+					newDayPlan.setStartDateAndDayNumber(tripOption.getStartDate(), dayNumber);
+					tripOption.getDayPlans().add(newDayPlan);
+					return newDayPlan;
+				});
+
+			// tourDetails 매핑
+			PTourDetail detail = tourDetailMap.get(item.getContentId());
+			if (detail != null) {
+				item.setTourDetail(detail);
+			}
+			dayPlan.getItems().add(item);
+		}
+
+		// dayPlans를 dayNumber 기준으로 정렬
+		tripOption.getDayPlans().sort(Comparator.comparingInt(UTripOption.DayPlan::getDayNumber));
 	}
 
 	/**
@@ -309,17 +418,20 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 		long hours = duration.toHours();
 		long minutes = duration.toMinutes();
 
+		String dayDiffWord;
+
 		if (years > 0) {
-			return years + "년 전";
+			dayDiffWord = years + "년 전";
 		} else if (months > 0) {
-			return months + "달 전";
+			dayDiffWord = months + "달 전";
 		} else if (days > 0) {
-			return days + "일 전";
+			dayDiffWord = days + "일 전";
 		} else if (hours > 0) {
-			return hours + "시간 전";
+			dayDiffWord = hours + "시간 전";
 		} else {
-			return minutes + "분 전";
+			dayDiffWord = minutes + "분 전";
 		}
+		return dayDiffWord;
 	}
 
 	private void saveRealMembers(String tripUuid, List<String> realMemberIds) {

--- a/src/main/resources/mapper/platform/trip/PTripPlanMapper.xml
+++ b/src/main/resources/mapper/platform/trip/PTripPlanMapper.xml
@@ -99,7 +99,6 @@
         UPDATE
             INDIVIDUAL_TRIP_PLAN
         SET
-            RGN_SCTGRY_CD       = #{planRegionSmallCate},
             TRIP_PLN_BGNG_YMD   = #{startDate},
             TRIP_PLN_END_YMD    = #{endDate},
             TRIP_PLN_DAY        = #{planDays},
@@ -303,6 +302,7 @@
             AND
             tour_detail_content_type_id = #{contentTypeId}
     </select>
+
     <select id="getSigunguNameBySigunCode" resultMap="sigunMap">
         /* 시군 코드와 일치하는 지역 코드 이름, 시군 코드 이름 조회 */
         SELECT

--- a/src/main/resources/mapper/user/trip/UTripPlanMapper.xml
+++ b/src/main/resources/mapper/user/trip/UTripPlanMapper.xml
@@ -7,10 +7,10 @@
         <result column="MBR_GRD_NO"   property="level"/>
         <result column="MBR_NM"       property="name"/>
         <result column="MBR_NICKNAME" property="nickname"/>
-
     </resultMap>
 
     <resultMap id="tripPlanMap" type="uTripOption">
+        <!-- INDIVIDUAL_TRIP_PLAN_NEW 테이블 resultMap-->
         <id     column="TRIP_PLAN_ID"        property="tripId"/>
         <result column="PLAN_UUID"           property="planUUID"/>
         <result column="SESSION_ID"          property="sessionId"/>
@@ -25,6 +25,39 @@
         <result column="REG_YMD"             property="regDate"/>
         <result column="MDFCN_YMD"           property="modDate"/>
         <result column="IN_PRGRS"            property="inProgress"/>
+    </resultMap>
+
+    <resultMap id="tripPlanItemsMap" type="UTripPlanItem">
+        <!-- TRIP_PLAN_ITEMS_NEW 테이블 resultMap-->
+        <id     column="ITEM_ID"      property="itemId"/>
+        <result column="PLAN_UUID"    property="planUUID"/>
+        <result column="DAY_NUMBER"   property="dayNumber"/>
+        <result column="CONTENT_ID"   property="contentId"/>
+        <result column="ORDER_NUMBER" property="orderNumber"/>
+        <result column="REG_YMD"      property="regDate"/>
+    </resultMap>
+
+    <resultMap id="tourDetailInfoMap" type="pTourDetail">
+        <!-- TOUR_DETAIL_FROM_API 테이블 resultMap -->
+        <id     column="tour_detail_content_id"      property="contentId"/>
+        <result column="tour_detail_content_type_id" property="contentTypeId"/>
+        <result column="tour_detail_title"           property="title"/>
+        <result column="tour_detail_homepage"        property="homepage"/>
+        <result column="tour_detail_first_image"     property="firstImage"/>
+        <result column="tour_detail_second_image"    property="secondImage"/>
+        <result column="area_code"                   property="areaCode"/>
+        <result column="sigungu_code"                property="sigunguCode"/>
+        <result column="tour_detail_first_addr"      property="mainAddr"/>
+        <result column="tour_detail_second_addr"     property="detailAddr"/>
+        <result column="tour_detail_zipcode"         property="zipcode"/>
+        <result column="tour_detail_tel_num"         property="tel"/>
+        <result column="tour_detail_tel_name"        property="telName"/>
+        <result column="tour_detail_longitude"       property="longitude"/>
+        <result column="tour_detail_latitude"        property="latitude"/>
+        <result column="tour_detail_mlevel"          property="mapLevel"/>
+        <result column="tour_detail_overview"        property="overview"/>
+        <result column="REG_YMD"                     property="regDate"/>
+        <result column="MDFCN_YMD"                   property="modDate"/>
     </resultMap>
 
     <insert id="addTempPlanInfo">
@@ -281,4 +314,106 @@
                 #{tripUuid},
                 #{realMemberId})
     </insert>
+
+    <select id="existsByPlanUUID" resultType="java.lang.Boolean">
+        /* 여행 계획 상세 정보가 존재하는지 확인 */
+        SELECT
+            COUNT(*) > 0
+        FROM
+            TRIP_PLAN_ITEMS_NEW
+        WHERE
+            PLAN_UUID = #{planUUID}
+    </select>
+
+    <delete id="deleteDetailInfo">
+        /* 여행 계획이 존재한다면 삭제 처리 */
+        DELETE
+        FROM
+            TRIP_PLAN_ITEMS_NEW
+        WHERE
+            plan_uuid = #{planUUID}
+    </delete>
+
+    <insert id="insertDetailInfo">
+        /* 여행 계획 상세 정보 저장 */
+        INSERT INTO
+            TRIP_PLAN_ITEMS_NEW (
+                                 PLAN_UUID,
+                                 DAY_NUMBER,
+                                 CONTENT_ID,
+                                 ORDER_NUMBER,
+                                 REG_YMD
+        )
+        VALUES (
+                #{planUUID},
+                #{dayNumber},
+                #{contentId},
+                #{order},
+                now()
+               )
+    </insert>
+
+    <select id="getTripPlanByUUID" resultMap="tripPlanMap">
+        /* INDIVIDUAL_TRIP_PLAN_NEW 테이블 조회 쿼리 */
+        SELECT
+            TRIP_PLAN_ID,
+            PLAN_UUID,
+            SESSION_ID,
+            TRIP_TITLE,
+            START_DATE,
+            END_DATE,
+            NUM_PEOPLE,
+            NUM_VIRTUAL_MEMBERS,
+            NUM_REAL_MEMBERS,
+            NUM_DATE,
+            TRIP_DURATION,
+            REG_YMD,
+            MDFCN_YMD,
+            IN_PRGRS
+        FROM
+            INDIVIDUAL_TRIP_PLAN_NEW
+        WHERE
+            PLAN_UUID = #{planUUID}
+    </select>
+
+    <select id="getTripItemsByUUID" resultMap="tripPlanItemsMap">
+        /* TRIP_PLAN_ITEMS_NEW 테이블 조회 쿼리 */
+        SELECT
+            ITEM_ID,
+            PLAN_UUID,
+            DAY_NUMBER,
+            CONTENT_ID,
+            ORDER_NUMBER,
+            REG_YMD
+        FROM
+            TRIP_PLAN_ITEMS_NEW
+        WHERE
+            PLAN_UUID = #{planUUID}
+    </select>
+
+    <select id="getPTourDetailByContentId" resultMap="tourDetailInfoMap">
+        /* TOUR_DETAIL_FROM_API 테이블 조회 쿼리 */
+        SELECT
+        tour_detail_content_id,
+        tour_detail_content_type_id,
+        tour_detail_title,
+        tour_detail_homepage,
+        tour_detail_first_image,
+        tour_detail_second_image,
+        area_code,
+        sigungu_code,
+        tour_detail_first_addr,
+        tour_detail_second_addr,
+        tour_detail_zipcode,
+        tour_detail_tel_num,
+        tour_detail_tel_name
+        FROM
+        TOUR_DETAIL_FROM_API
+        WHERE
+        tour_detail_content_id IN
+        <foreach item="item" collection="contentIds" open="(" separator="," close=")">
+            #{item}
+        </foreach>
+    </select>
+
 </mapper>

--- a/src/main/resources/static/user/js/trip/backToPlanList.js
+++ b/src/main/resources/static/user/js/trip/backToPlanList.js
@@ -1,0 +1,6 @@
+$(document).ready(function(){
+    // 목록으로 되돌아가는 버튼 이벤트 핸들러
+    $('#backToListButton').click(function() {
+        window.location.href = '/trip/list';
+    });
+})

--- a/src/main/resources/static/user/js/trip/tripPlan.js
+++ b/src/main/resources/static/user/js/trip/tripPlan.js
@@ -46,6 +46,8 @@ function moveToNextAccordion() {
     }, 0);
 }
 
+
+
 // 첫번째 아코디언으로 되돌아가는 함수
 function backToFirstStepStage() {
     // 사용자에게 확인 메시지를 보여주고, 확인 시에만 계속 진행

--- a/src/main/resources/static/user/js/trip/tripPlanLoad.js
+++ b/src/main/resources/static/user/js/trip/tripPlanLoad.js
@@ -488,3 +488,64 @@ $('#distanceCalBTN').click(function() {
         }
     });
 });
+
+// 저장 버튼 클릭 이벤트 핸들러
+$('#saveDetailInfoBtn').click(function() {
+    // saveTripInfo 함수 내부에서 UUID 값 설정
+    $('#planUUID').val(uuid);
+
+    // 저장할 데이터 객체 생성
+    const data = {
+        planUUID: uuid, // UUID를 기본 키(PK)로 사용
+        days: []
+    };
+
+    // 각 일자별 데이터 수집
+    $('#myDayTabContent > .tab-pane').each(function() {
+        const dayNumber = $(this).attr('id').replace('day', '');
+        const planDayId = `planDay${dayNumber}`;
+        const $planDay = $(`#${planDayId}`);
+
+        const day = {
+            day: dayNumber,
+            locations: []
+        };
+
+        $planDay.find('li').each(function(idx, element) {
+            const contentId = $(element).find('h4')[0].dataset.contentId;
+            const order = $(element).find('span.number').text();
+
+            day.locations.push({
+                contentId,
+                order
+            });
+        });
+
+        data.days.push(day);
+    });
+
+    // AJAX POST 요청 보내기
+    $.ajax({
+        url: '/trip/save-trip-detail-info', // 서버 엔드포인트 URL
+        type: 'POST',
+        data: JSON.stringify(data), // 데이터를 JSON 문자열로 변환
+        contentType: 'application/json', // 전송 데이터 타입 설정
+        dataType: 'text', // 응답 데이터 타입 설정
+        success: function(response) {
+            // 서버에서 반환한 문자열을 출력
+            console.log('Response:', response);
+            // 반환된 문자열에 따라 성공 또는 실패 메시지 출력
+            if (response === "success") {
+                alert('일정 정보가 성공적으로 저장되었습니다.');
+                window.location.href = '/trip/list';
+            } else {
+                alert('일정 정보 저장 하는데 실패했습니다.');
+            }
+        },
+        error: function(xhr, status, error) {
+            // 오류 시 처리 로직
+            console.error('Error:', error);
+            alert('일정 정보 저장 중 오류가 발생했습니다.');
+        }
+    });
+});

--- a/src/main/resources/static/user/js/trip/tripPlanner.js
+++ b/src/main/resources/static/user/js/trip/tripPlanner.js
@@ -48,7 +48,6 @@ $(document).ready(function() {
 
         addToPlan(name, category, schedule, additional, id, contentId);
     });
-
 });
 
 // 탭 패널 ID에 따라 숙박, 식당, 관광지 중 하나를 반환

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -173,10 +173,13 @@
                                 <a href="/trip/list" target="_blank">내 여행 계획 목록 조회</a>
                             </li>
                             <li>
-                                <a href="/trip/schedule" target="_blank">내 여행 계획 조회</a>
+                                <a href="/trip/schedule?planUUID=23dca803-0364-4939-a3c5-573bb1751386" target="_blank">내 여행 계획 상세 조회</a>
                             </li>
                             <li>
                                 <a href="/trip/board" target="_blank">여행 계획 공유 게시판</a>
+                            </li>
+                            <li>
+                                <a href="/trip/tourInfo" target="_blank">여행지 조회 페이지</a>
                             </li>
                         </ul>
                     </li>
@@ -403,7 +406,7 @@
     $modalLinks.forEach(function (link) {
         link.addEventListener('click', function () {
             const modalName = this.getAttribute('data-modal');
-            console.log(modalName);
+            // console.log(modalName);
             localStorage.setItem('showModal', modalName);
         });
     });

--- a/src/main/resources/templates/user/error/error.html
+++ b/src/main/resources/templates/user/error/error.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Error</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f2f2f2;
+      text-align: center;
+      padding: 50px;
+    }
+    .error {
+      font-size: 24px;
+      color: red;
+    }
+  </style>
+</head>
+<body>
+<div class="error">
+  <h1>오류 발생</h1>
+  <p>요청 처리 중에 에러가 발생했습니다.</p>
+  <p th:if="${exception != null}" th:text="${exception.message}"></p>
+  <p>URL: <span th:text="${url}"></span></p>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/user/fragments/header.html
+++ b/src/main/resources/templates/user/fragments/header.html
@@ -28,10 +28,13 @@
                                 <a th:href="@{/trip/detail}">내 여행 계획 작성</a>
                             </li>
                             <li class="">
-                                <a th:href="@{/trip/schedule}">여행 스케줄</a>
+                                <a th:href="@{/trip/schedule?planUUID=23dca803-0364-4939-a3c5-573bb1751386}">여행 스케줄</a>
                             </li>
                             <li class="">
                                 <a th:href="@{/trip/board}">여행 계획 공유 게시판</a>
+                            </li>
+                            <li class="">
+                                <a th:href="@{/trip/tourInfo}">여행지 조회</a>
                             </li>
                         </ul>
                     </li>

--- a/src/main/resources/templates/user/index.html
+++ b/src/main/resources/templates/user/index.html
@@ -9,6 +9,7 @@
 </th:block>
 
 <th:block layout:fragment="customPageSection">
+    <div th:if="${message}" class="alert alert-info" role="alert" th:text="${message}"></div>
     <div class="hero">
         <div class="container">
             <div class="row align-items-center">
@@ -23,27 +24,16 @@
                             <div class="col-12">
                                 <form class="form" method="post" th:action="@{/trip/detail}">
                                     <div class="row mb-2">
-                                        <div class="col-sm-12 col-md-6 mb-3 mb-lg-0 col-lg-4">
-                                            <select class="form-control custom-select" id="" name="">
-                                                <option value="">지역</option>
-                                                <option value="">Peru</option>
-                                                <option value="">Japan</option>
-                                                <option value="">Thailand</option>
-                                                <option value="">Brazil</option>
-                                                <option value="">United States</option>
-                                                <option value="">Israel</option>
-                                                <option value="">China</option>
-                                                <option value="">Russia</option>
-                                            </select>
-                                        </div>
-                                        <div class="col-sm-12 col-md-6 mb-3 mb-lg-0 col-lg-5">
+
+                                        <div class="col-sm-12 col-md-6 mb-3 mb-lg-6 col-lg-6">
                                             <input type="text" name="daterange" id="dateRange" class="form-control">
                                             <input type="hidden" name="startDate" id="startDate">
                                             <input type="hidden" name="endDate" id="endDate">
                                             <div th:if="${errorMessage}" th:text="${errorMessage}"></div>
                                         </div>
-                                        <div class="col-sm-12 col-md-6 mb-3 mb-lg-0 col-lg-3">
-                                            <input type="number" class="form-control" name="numPeople" id="numPeople" placeholder="인원 수를 입력하세요">
+                                        <div class="col-sm-12 col-md-6 mb-3 mb-lg-6 col-lg-6">
+                                            <input type="number" class="form-control" name="numPeople"
+                                                   id="numPeople" placeholder="인원 수를 입력하세요">
                                         </div>
 
                                     </div>
@@ -52,13 +42,7 @@
                                             <input class="btn btn-primary btn-block" type="submit"
                                                    value="작성">
                                         </div>
-                                        <div class="col-lg-8">
-                                            <label class="control control--checkbox mt-3">
-                                                <span class="caption">Save this search</span>
-                                                <input checked="checked" type="checkbox"/>
-                                                <div class="control__indicator"></div>
-                                            </label>
-                                        </div>
+
                                     </div>
                                 </form>
                             </div>

--- a/src/main/resources/templates/user/layout/default.html
+++ b/src/main/resources/templates/user/layout/default.html
@@ -82,6 +82,7 @@
             ===================================== -->
 		<section>
 			<div class="container">
+
 				<!-- Elements Breadcrumb -->
 				<div class="pt-5 mb-5" id="breadcrumb">
 					<div class="row">

--- a/src/main/resources/templates/user/trip/planList.html
+++ b/src/main/resources/templates/user/trip/planList.html
@@ -9,6 +9,7 @@
         <div th:each="plan, iterStat : ${plans}"
              th:id="${'plan-'+iterStat.count}"
              class="list-group-item list-group-item-action flex-column align-items-start">
+            <input type="hidden" th:value="${plan.planUUID}">
             <div class="d-flex w-100 justify-content-between">
                 <h5 class="mb-1">
                     <small th:text="${iterStat.count}">1</small>
@@ -18,7 +19,7 @@
             </div>
             <div class="d-flex w-100 justify-content-between">
                 <p class="mb-1" th:text="${plan.description}">여행 계획에 대한 간단한 설명이나 세부사항</p>
-                <button class="btn btn-primary share-btn" th:data-plan-id="${plan.tripId}">공유하기</button>
+                <button class="btn btn-primary btn-xs share-btn" th:data-plan-id="${plan.tripId}">공유하기</button>
             </div>
             <div class="d-flex w-25 justify-content-between">
                 <small>인원: <span th:text="${plan.numPeople}">4</span></small>
@@ -29,9 +30,9 @@
         </div>
     </div>
 
-        <!-- 여행 계획 데이터 정적 표시 -->
-    <div class="list-group">
-        <!-- 제주도 여행 계획 -->
+        <!-- 여행 계획 데이터 예시 -->
+    <!--/*<div class="list-group">
+        &lt;!&ndash; 제주도 여행 계획 &ndash;&gt;
         <div class="list-group-item list-group-item-action flex-column align-items-start" id="plan-1">
             <div class="d-flex w-100 justify-content-between">
                 <h5 class="mb-1">
@@ -52,7 +53,7 @@
                 <small>기간: <span>3박 4일</span></small>
             </div>
         </div>
-        <!-- 경주 역사 여행 계획 -->
+        &lt;!&ndash; 경주 역사 여행 계획 &ndash;&gt;
         <div class="list-group-item list-group-item-action flex-column align-items-start" id="plan-2">
             <div class="d-flex w-100 justify-content-between">
                 <h5 class="mb-1">
@@ -73,7 +74,7 @@
                 <small>기간: <span>2박 3일</span></small>
             </div>
         </div>
-    </div>
+    </div>*/-->
 
 
 
@@ -86,7 +87,9 @@
         $(document).ready(function() {
             $(".list-group-item").click(function(e) {
                 const planId = $(this).attr('id').split('-')[1];
-                window.location.href = "/plan/detail/" + planId;
+                const planUUID = $(this).find('input').val();
+                console.log(planUUID)
+                window.location.href = "/trip/schedule?planUUID=" + planUUID;
             });
 
             $(".share-btn").click(function(e) {

--- a/src/main/resources/templates/user/trip/planSchedule.html
+++ b/src/main/resources/templates/user/trip/planSchedule.html
@@ -6,162 +6,46 @@
 </th:block>
 
 <th:block layout:fragment="customPageSection">
-    <h2 class="text-uppercase text-letter-spacing-xs my-0 text-primary font-weight-bold">
-        Schedule
-    </h2>
+    <div class="d-flex justify-content-end">
+        <button class="btn btn-primary btn-sm me-2" type="button" id="modifyPlan">수정(구현 안됨)</button>
+        <button class="btn btn-secondary btn-sm" id="backToListButton" type="button">목록으로</button>
+    </div>
+    <h2 class="text-uppercase text-letter-spacing-xs my-0 text-primary font-weight-bold"
+        th:if="${tripOption != null}" th:text="${tripOption.tripTitle}">Schedule</h2>
+    <h2 class="text-uppercase text-letter-spacing-xs my-0 text-primary font-weight-bold"
+        th:unless="${tripOption != null}">Schedule</h2>
+    <p>
+        출발 날짜: <span th:text="${tripOption.startDate}">출발 날짜</span>,
+        도착 날짜: <span th:text="${tripOption.endDate}">도착 날짜</span>
+    </p>
     <!-- Days -->
     <div class="row mt-7">
-        <div th:each="day, dayStat : ${days}" class="col-lg-6 mb-3" th:id="'day-' + ${dayStat.index}">
+        <div th:if="${tripOption != null}" th:each="dayPlan, dayStat : ${tripOption.dayPlans}" class="col-lg-6 mb-3" th:id="'day-' + ${dayStat.index}">
             <h4 class="mt-0 mb-3 text-dark op-8 font-weight-bold">
-                <span th:text="${day.date}">05월 08일 수요일</span>
+                <span th:text="${#temporals.format(dayPlan.date, 'yyyy년 MM월 dd일 EEEE')}">05월 08일 수요일</span>
             </h4>
             <ul class="list-timeline list-timeline-primary">
-                <!-- 등록 시간 -->
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
+                <!-- 등록 시간 : 미구현 -->
+                <!--/*<li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
                     <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">09:00 - 10:00</span> - 등록</p>
-                </li>
+                </li>*/-->
                 <!-- 일정 항목 반복 시작 -->
-                <div th:each="item, itemStat : ${day.items}">
+                <div th:each="item, itemStat : ${dayPlan.items}">
                     <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" th:data-toggle="'collapse'" th:data-target="'#day-' + ${dayStat.index} + '-item-' + ${itemStat.index}">
-                        <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8" th:text="${item.time}">16:00 - 18:00</span> - <span th:text="${item.name}">이름</span></p>
-                        <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8 show" th:id="'day-' + ${dayStat.index} + '-item-' + ${itemStat.index}" th:text="${item.description}">세부 설명</p>
+                        <p class="my-0 text-dark flex-fw text-sm text-uppercase"> - <span th:text="${item.tourDetail.title}">이름</span></p>
+                        <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8 show" th:id="'day-' + ${dayStat.index} + '-item-' + ${itemStat.index}" th:text="${item.tourDetail.mainAddr}">주소</p>
                     </li>
                 </div>
                 <!-- 일정 항목 반복 종료 -->
-                <!-- 컨퍼런스 종료 후 -->
-                <li class="list-timeline-item p-0 pb-3 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">18:00 - 23:00</span> - 컨퍼런스 종료 후</p>
-                </li>
-            </ul>
-        </div>
-        <div class="col-lg-6 mb-3" id="Wednesday, May 08th">
-            <h4 class="mt-0 mb-3 text-dark op-8 font-weight-bold">
-                05월 08일 수요일
-            </h4>
-            <ul class="list-timeline list-timeline-primary">
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">09:00 - 10:00</span> - Registration</p>
-                </li>
-                <li class="list-timeline-item show p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-1-item-2">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-primary font-weight-bold op-8 infinite animated flash" data-animate="flash" data-animate-infinite="1" data-animate-duration="3.5" style="animation-duration: 3.5s;">Now</span> - Vitaly Friedmann</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8 show" id="day-1-item-2"> Talk: Wireframing / <span class="text-primary">Room 19</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">12:00 - 13:00</span> - Lunch Break</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-1-item-4">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">13:00 - 15:00</span> - Anthony Jonas</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-1-item-4"> Talk: OpenData / <span class="text-primary">Room 31</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">15:00 - 16:00</span> - Coffee Break</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-1-item-6">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">16:00 - 18:00</span> - Jesscia Lawrence</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-1-item-6"> Talk: Ninja coding / <span class="text-primary">Room 31</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">18:00 - 23:00</span> - After conference</p>
-                </li>
-            </ul>
-        </div>
-        <div class="col-lg-6 mb-3" id="Thursday, May 09th">
-            <h4 class="mt-0 mb-3 text-dark op-8 font-weight-bold">
-                05월 09일 목요일
-            </h4>
-            <ul class="list-timeline list-timeline-primary">
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">09:00 - 10:00</span> - Registration</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-2-item-2">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">10:00 - 12:00</span> - Vitaly Friedmann</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-2-item-2"> Talk: Wireframing / <span class="text-primary">Room 19</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">12:00 - 13:00</span> - Lunch Break</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-2-item-4">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">13:00 - 15:00</span> - Bruce Lawson</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-2-item-4"> Talk: Big Data / <span class="text-primary">Room 19</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">15:00 - 16:00</span> - Coffee Break</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-2-item-6">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">16:00 - 18:00</span> - Anthony Jonas</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-2-item-6"> Talk: OpenData / <span class="text-primary">Room 31</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">18:00 - 23:00</span> - After conference</p>
-                </li>
-            </ul>
-        </div>
-        <div class="col-lg-6 mb-3" id="Friday, May 10th">
-            <h4 class="mt-0 mb-3 text-dark op-8 font-weight-bold">
-                05월 10일 금요일
-            </h4>
-            <ul class="list-timeline list-timeline-primary">
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">09:00 - 10:00</span> - Registration</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-3-item-2">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">10:00 - 12:00</span> - Jesscia Lawrence</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-3-item-2"> Talk: Ninja coding / <span class="text-primary">Room 31</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">12:00 - 13:00</span> - Lunch Break</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-3-item-4">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">13:00 - 15:00</span> - Anthony Jonas</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-3-item-4"> Talk: OpenData / <span class="text-primary">Room 31</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">15:00 - 16:00</span> - Coffee Break</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-3-item-6">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">16:00 - 18:00</span> - Anthony Jonas</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-3-item-6"> Talk: OpenData / <span class="text-primary">Room 31</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">18:00 - 23:00</span> - After conference</p>
-                </li>
-            </ul>
-        </div>
-        <div class="col-lg-6 mb-3" id="Saturday, May 11th">
-            <h4 class="mt-0 mb-3 text-dark op-8 font-weight-bold">
-                05월 11일 토요일
-            </h4>
-            <ul class="list-timeline list-timeline-primary">
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">09:00 - 10:00</span> - Registration</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-3-item-2">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">10:00 - 12:00</span> - Jesscia Lawrence</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-4-item-2"> Talk: Ninja coding / <span class="text-primary">Room 31</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">12:00 - 13:00</span> - Lunch Break</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-3-item-4">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">13:00 - 15:00</span> - Anthony Jonas</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-4-item-4"> Talk: OpenData / <span class="text-primary">Room 31</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">15:00 - 16:00</span> - Coffee Break</p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 pb-lg-4 d-flex flex-wrap flex-column" data-toggle="collapse" data-target="#day-3-item-6">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">16:00 - 18:00</span> - Anthony Jonas</p>
-                    <p class="my-0 collapse flex-fw text-uppercase text-xs text-dark op-8" id="day-4-item-6"> Talk: OpenData / <span class="text-primary">Room 31</span> </p>
-                </li>
-                <li class="list-timeline-item p-0 pb-3 d-flex flex-wrap flex-column">
-                    <p class="my-0 text-dark flex-fw text-sm text-uppercase"><span class="text-inverse op-8">18:00 - 23:00</span> - After conference</p>
-                </li>
             </ul>
         </div>
     </div>
 </th:block>
 
-<th:block layout:fragment="customJsFIle"></th:block>
+<th:block layout:fragment="customJsFIle">
+    <!--2024.06.09-->
+    <script th:src="@{/user/js/trip/backToPlanList.js}"></script>
+</th:block>
 
 <th:block layout:fragment="customJs"></th:block>
 </html>

--- a/src/main/resources/templates/user/trip/tourInfo.html
+++ b/src/main/resources/templates/user/trip/tourInfo.html
@@ -11,34 +11,38 @@
         <div class="container">
             <div class="row">
                 <div class="d-flex mb-5">
-                    <div class="col-md-5 col-sm-5 col-xs-5">
-                        <label for="areaCode" class="col-md-4 col-sm-4 col-xs-6">지역 코드:</label>
-                        <select id="areaCode" name="areaCode" class="text-center form-select-lg w-75" required>
+                    <div class="col-md-3 col-sm-3 col-xs-4">
+                        <label for="contentTypeId" class="form-label">여행지 분류:</label>
+                        <select id="contentTypeId" name="contentTypeId" class="text-center form-select form-select-lg w-100" required>
+                            <option value="">=== 여행지 ===</option>
+                            <option value="12">관광지</option>
+                            <option value="32">숙박</option>
+                            <option value="39">음식점</option>
+                        </select>
+                    </div>
+                    <div class="col-md-3 col-sm-3 col-xs-4">
+                        <label for="areaCode" class="form-label">지역 코드:</label>
+                        <select id="areaCode" name="areaCode" class="text-center form-select form-select-lg w-100" required>
                             <option value="">=== 지역 코드 ===</option>
                             <th:block th:each="list : ${areaCodeList}">
                                 <option th:value="${list.areaCode}" th:text="${list.areaName}"></option>
                             </th:block>
                         </select>
-                        <br>
                     </div>
-
-                    <div class="col-md-5 col-sm-5 col-xs-5">
-                    <label for="sigunguCode" class="col-md-4 col-sm-4 col-xs-6">시군 코드:</label>
-
-                        <select id="sigunguCode" name="sigunguCode" class="text-center form-select-lg w-75" required>
+                    <div class="col-md-3 col-sm-3 col-xs-4">
+                        <label for="sigunguCode" class="form-label">시군 코드:</label>
+                        <select id="sigunguCode" name="sigunguCode" class="text-center form-select form-select-lg w-100" required>
                             <option value="">=== 시군 코드 ===</option>
                         </select>
                     </div>
-                    <div class="col-md-2 col-sm-2 col-xs-2">
-                        <label>
-                            목록 표시
-                            <select id="contentAmount" class="form-select-sm">
-                                <option value="10">10 개</option>
-                                <option value="20">20 개</option>
-                                <option value="30">30 개</option>
-                                <option value="50">50 개</option>
-                            </select>
-                        </label>
+                    <div class="col-md-3 col-sm-3 col-xs-4">
+                        <label for="contentAmount" class="form-label">목록 표시:</label>
+                        <select id="contentAmount" class="text-center form-select form-select-lg w-100">
+                            <option value="12">4 줄</option>
+                            <option value="21">7 줄</option>
+                            <option value="30">10 줄</option>
+                            <option value="51">17 줄</option>
+                        </select>
                     </div>
                 </div>
 
@@ -122,7 +126,14 @@
             cardBodyDiv.appendChild(h5);
 
             const p = document.createElement('p');
-            p.className = 'mb-5';
+            p.className = 'mb-3';
+            p.style.display = '-webkit-box';
+            p.style.WebkitLineClamp = '4';
+            p.style.WebkitBoxOrient = 'vertical';
+            p.style.overflow = 'hidden';
+            p.style.textOverflow = 'ellipsis';
+            p.style.lineHeight = '1.5em';
+            p.style.maxHeight = '6em';  // 4 lines * 1.5em line-height
             p.textContent = tourData.contentOverview;
 
             cardBodyDiv.appendChild(p);
@@ -137,14 +148,14 @@
             tourListContainer.replaceChildren(...tourDataList.map(createTourCard));
         }
 
-        function action(data, pageNum, amount, areaCode, sigunguCode) {
+        function action(data, pageNum, amount, areaCode, sigunguCode, contentTypeId) {
             const tourListContainer = document.getElementById('tourList');
             const paginationContainer = document.getElementById('tourPagination');
 
             pageNum = currentPageNum;
 
-            if (areaCode && sigunguCode) {
-                data = data.filter(item => item.areaCode === areaCode && item.sigunguCode === sigunguCode);
+            if (areaCode && sigunguCode && contentTypeId) {
+                data = data.filter(item => item.areaCode === areaCode && item.sigunguCode === sigunguCode && item.contentTypeId === contentTypeId);
             }
 
             let lastPage = Math.ceil(data.length / Number(amount));
@@ -249,16 +260,16 @@
             const amount = document.getElementById('contentAmount').value;
             const areaCode = document.getElementById('areaCode').value;
             const sigunguCode = this.value;
-            console.log(sigunguCode);
+            const contentTypeId = document.getElementById('contentTypeId').value;
 
             request.get('/trip/tourInfo/tourData')
                 .then(response => response.json())
                 .then(tourDataList => {
                     const filteredList = tourDataList.filter(item =>
-                        item.areaCode === areaCode && item.sigunguCode === sigunguCode
+                        item.areaCode === areaCode && item.sigunguCode === sigunguCode && item.contentTypeId === contentTypeId
                     );
                     renderTourList(filteredList);
-                    action(filteredList, currentPageNum, amount, areaCode, sigunguCode);
+                    action(filteredList, currentPageNum, amount, areaCode, sigunguCode, contentTypeId);
                 })
                 .catch(err => console.error(err));
         });
@@ -268,15 +279,17 @@
             const areaCode = document.getElementById('areaCode').value;
             const sigunguCode = document.getElementById('sigunguCode').value;
             const hasHref = event.target.getAttribute('href');
+            const contentTypeId = document.getElementById('contentTypeId').value;
+
             if (hasHref != null) {
                 currentPageNum = parseInt(event.target.dataset.pageNum);
                 request.get('/trip/tourInfo/tourData')
                     .then(response => response.json())
                     .then(tourDataList => {
                         let filteredList = tourDataList.filter(item =>
-                            item.areaCode === areaCode && item.sigunguCode === sigunguCode
+                            item.areaCode === areaCode && item.sigunguCode === sigunguCode && item.contentTypeId === contentTypeId
                         );
-                        action(filteredList, currentPageNum, amount, areaCode, sigunguCode);
+                        action(filteredList, currentPageNum, amount, areaCode, sigunguCode, contentTypeId);
                     })
                     .catch(err => console.error(err));
             }
@@ -286,14 +299,15 @@
             const amount = this.value;
             const areaCode = document.getElementById('areaCode').value;
             const sigunguCode = document.getElementById('sigunguCode').value;
+            const contentTypeId = document.getElementById('contentTypeId').value;
 
             request.get('/trip/tourInfo/tourData')
                 .then(response => response.json())
                 .then(tourDataList => {
                     let filteredList = tourDataList.filter(item =>
-                        item.areaCode === areaCode && item.sigunguCode === sigunguCode
+                        item.areaCode === areaCode && item.sigunguCode === sigunguCode && item.contentTypeId === contentTypeId
                     );
-                    action(filteredList, currentPageNum, amount, areaCode, sigunguCode);
+                    action(filteredList, currentPageNum, amount, areaCode, sigunguCode, contentTypeId);
                 })
                 .catch(err => console.error(err));
         });
@@ -307,6 +321,7 @@
                 data: { areaCode: $areaCode },
                 success: function(data) {
                     $('#sigunguCode').empty();
+                    $('#sigunguCode').append('<option value="">=== 시군 코드 ===</option>');
                     $.each(data, function(index, item) {
                         $('#sigunguCode').append('<option value="' + item.sigunguCode + '">' + item.sigunguName + '</option>');
                     });

--- a/src/main/resources/templates/user/trip/tripPlan.html
+++ b/src/main/resources/templates/user/trip/tripPlan.html
@@ -24,10 +24,11 @@
                 <div class="accordion-body">
                     <!-- 첫 번째 페이지 내용 -->
                     <form th:action="@{/trip/details}" method="post" th:object="${uTripOption}" id="tripPlanForm">
-                        <input type="text" hidden="hidden" name="sessionId" id="sessionId" th:value="${session.loginId}">
+                        <input type="hidden" id="sessionId" name="sessionId" th:value="${session.loginId}">
+                        <input type="hidden" id="planUUID" name="planUUID" value="">
                         <div class="d-flex justify-content-end">
                             <button class="btn btn-primary btn-sm me-2" type="button" id="tmpSave" onclick="firstStepSubmit()">임시 저장</button>
-                            <button class="btn btn-secondary btn-sm" type="button">목록으로</button>
+                            <button class="btn btn-secondary btn-sm" id="backToListButton" type="button">목록으로</button>
                         </div>
                         <div class="mb-3">
                             <label for="tripTitle" class="form-label">여행 제목:</label>
@@ -121,7 +122,7 @@
                     <!-- 두 번째 페이지 내용 -->
                     <div class="row justify-content-between">
                         <div class="d-flex justify-content-end">
-                            <button class="btn btn-primary btn-sm me-2" type="button">저장</button>
+                            <button class="btn btn-primary btn-sm me-2 saveDetailInfoBtn" id="saveDetailInfoBtn" type="button">저장</button>
                             <button class="btn btn-secondary btn-sm" type="button" onclick="backToFirstStepStage()">이전으로</button>
                         </div>
                         <!-- 지역 선택 -->
@@ -445,6 +446,9 @@
 
     <!--2024.06.04-->
     <script th:src="@{/user/js/trip/tripPlanLoad.js}"></script>
+
+    <!--2024.06.09-->
+    <script th:src="@{/user/js/trip/backToPlanList.js}"></script>
 </th:block>
 
 <th:block layout:fragment="customJs"></th:block>


### PR DESCRIPTION
DETAIL: 
240609 20:17
여행 계획 쪽 Breadcrumb 동적으로 작성되도록 수정,
유저 페이지 에러 관리 페이지 작성 완료,
여행 계획 작성 헤더 메뉴 수정,
project information 페이지 수정,
여행 계획 페이지 조회 시 로그인 되어 있지 않으면 /trip 으로 리다이렉트 되도록 수정,
내 여행 계획 조회 페이지 UUID를 기준으로 연결되도록 수정,
세부 아이템 페이지에서 저장 버튼을 누르면 DB에 저장 처리,
내 계획 목록에서 각 계획을 조회하면 스케줄 형식으로 보이도록 표시 처리 완료,
여행 작성 페이지와 조회 페이지에서 목록으로 버튼을 같은 js 함수를 이용하도록 수정

EDIT: 
Breadcrumb.java
default.html
header.html
index.html
index.html
planList.html
planSchedule.html
PTripPlanMapper.xml
tourInfo.html
tripPlan.html
tripPlan.js
tripPlanLoad.js
tripPlanner.js
UTripOption.java
UTripPlanController.java
UTripPlanMapper.java
UTripPlanMapper.xml
UTripPlanService.java
UTripPlanServiceImpl.java
WebConfig.java

CREATE:
user\interceptor\AuthenticationInterceptor.java
\user\js\trip\backToPlanList.js
user\error\error.html
user\interceptor\RedirectAttributesInterceptor.java
user\exception\UserExceptionController.java
user\trip\dto\UTripDetailOption.java
user\trip\dto\UTripPlanItem.java

TO DO: 
수정 버튼을 누르면 현재 작성 페이지에 관련 값들이 다 들어온 상태로 오도록 표시,
내 계획 목록이나 조회 페이지에서 공유 버튼을 누르면 게시판으로 작성해 정보를 가져오는 페이지 작성