### PR TITLE
[ks50team01-bit] 여행 계획 조회 페이지 작성 중

### DIFF
--- a/src/main/java/ksmart/ks50team01/platform/trip/config/TripWebConfig.java
+++ b/src/main/java/ksmart/ks50team01/platform/trip/config/TripWebConfig.java
@@ -1,0 +1,39 @@
+package ksmart.ks50team01.platform.trip.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.resource.PathResourceResolver;
+
+@Configuration
+public class TripWebConfig implements WebMvcConfigurer {
+	private static String imageDirPath = "/home/teamproject/resources/tourapi/";
+
+	/**
+	 * 주소요청에 따른 외부파일 경로 설정
+	 */
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		String rootPath = getOSFilePath();
+		registry.addResourceHandler("/tourapi/**")
+			.addResourceLocations(rootPath + imageDirPath)
+			.setCachePeriod(3600)
+			.resourceChain(true)
+			.addResolver(new PathResourceResolver());
+		WebMvcConfigurer.super.addResourceHandlers(registry);
+	}
+
+	public String getOSFilePath() {
+		String rootPath = "file:///";
+		String os = System.getProperty("os.name").toLowerCase();
+
+		if(os.contains("win")) {
+			rootPath = "file:///d:";
+		}else if(os.contains("linux")) {
+			rootPath = "file:///";
+		}else if(os.contains("mac")){
+			rootPath = "file:///Users/Shared";
+		}
+		return rootPath;
+	}
+}

--- a/src/main/java/ksmart/ks50team01/platform/trip/service/PTripPlanServiceImpl.java
+++ b/src/main/java/ksmart/ks50team01/platform/trip/service/PTripPlanServiceImpl.java
@@ -190,8 +190,7 @@ public class PTripPlanServiceImpl implements PTripPlanService {
 	 * 서버에 이미지를 저장하는 메서드
 	 * @param contentId 컨텐트 ID
 	 * @param imageUrl 이미지 주소
-	 * @return
-	 * @throws IOException
+	 * @return DB에 저장된 이미지 파일 경로
 	 */
 	private String saveImageToServer(String contentId, String imageUrl) throws IOException {
 		String imageDirPath = "/home/teamproject/resources/tourapi/";
@@ -211,13 +210,15 @@ public class PTripPlanServiceImpl implements PTripPlanService {
 		try (InputStream inputStream = url.openStream()) {
 			// 서버에 이미지 저장
 			Files.copy(inputStream, imageFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		}catch(Exception e) {
+			log.error("이미지 저장하는 과정에서 문제가 발생했습니다", e);
 		}
 
 		return imagePath;
 	}
 
 	/**
-	 * 여행지 상세 정보 목록 조
+	 * 여행지 상세 정보 목록 조회
 	 * @return
 	 */
 	@Override

--- a/src/main/java/ksmart/ks50team01/user/config/WebConfig.java
+++ b/src/main/java/ksmart/ks50team01/user/config/WebConfig.java
@@ -45,7 +45,8 @@ public class WebConfig implements WebMvcConfigurer {
 				"/trip/logout",
 				"/trip", "/trip/",
 				"/trip/tourInfo/**",
-				"/trip/board"
+				"/trip/board",
+				"/tourapi/**"
 			);
 	}
 }

--- a/src/main/java/ksmart/ks50team01/user/trip/mapper/UTripPlanMapper.java
+++ b/src/main/java/ksmart/ks50team01/user/trip/mapper/UTripPlanMapper.java
@@ -61,21 +61,34 @@ public interface UTripPlanMapper {
 	// 여행 계획 목록 조회
 	List<UTripOption> selectTempPlanListBySessionId(String sessionId);
 
-	// Tour API에서 DB에 저장한 여행 상세 정보 목록 조
+	// Tour API에서 DB에 저장한 여행 상세 정보 목록 조회
 	List<Map<String, Object>> getTourDataList();
 
+	// UUID와 일치하는 여행 계획이 존재하는지 조회
 	boolean existsByPlanUUID(String planUUID);
 
+	// UUID와 일치하는 여행 계획을 삭제
 	int deleteDetailInfo(String planUUID);
 
-	int insertDetailInfo(@Param("planUUID") String planUUID,
+	// UUID와 여행 계획을 저장
+	int insertDetailInfo(
+		@Param("planUUID") String planUUID,
 		@Param("dayNumber") int dayNumber,
 		@Param("contentId") String contentId,
 		@Param("order") int order);
 
+	// UUID와 일치하는 여행 계획을 조회
 	UTripOption getTripPlanByUUID(String planUUID);
 
+	// UUID와 일치하는 여행 계획 세부 아이템 조회
 	List<UTripPlanItem> getTripItemsByUUID(String planUUID);
 
+	// 컨텐트 ID와 일치하는 여행 상세 정보 조회
 	List<PTourDetail> getPTourDetailByContentId(List<String> contentIds);
+
+	// UUID와 일치하는 여행에 초대받은 실제 회원 조회
+	List<String> getRealMembersByPlanUUID(String planUUID);
+
+	// UUID와 일치하는 여행에 초대받은 가상 회원 조회
+	List<String> getVirtualMembersByPlanUUID(String planUUID);
 }

--- a/src/main/java/ksmart/ks50team01/user/trip/service/UTripPlanServiceImpl.java
+++ b/src/main/java/ksmart/ks50team01/user/trip/service/UTripPlanServiceImpl.java
@@ -155,9 +155,11 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 				ULocationDistanceInfo startPoint = uDayInfo.getLocations().get(i);
 				ULocationDistanceInfo endPoint = uDayInfo.getLocations().get(i + 1);
 
+				// 각 지점의 위도와 경도를 데이터베이스에서 조회
 				Map<String, Object> startXY = uTripPlanMapper.getMapXY(startPoint.getContentId());
 				Map<String, Object> endXY = uTripPlanMapper.getMapXY(endPoint.getContentId());
 
+				// 시작점과 끝점의 위도, 경도 설정
 				startPoint.setStartMapX((Double)startXY.get("longitude"));
 				startPoint.setStartMapY((Double)startXY.get("latitude"));
 				endPoint.setEndMapX((Double)endXY.get("longitude"));
@@ -168,6 +170,7 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 				TMapApiResponse apiResponse;
 				try {
 					// 오류가 발생하지 않았을 경우
+					// T map API를 호출하여 두 지점 사이의 거리와 소요 시간 계산
 					apiResponse = uTmapApiService.fetchFromApi(
 						startPoint.getContentId(), endPoint.getContentId(),
 						startPoint.getStartMapX(), startPoint.getStartMapY(),
@@ -313,6 +316,12 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 	public UTripOption getTripOptionByUUID(String planUUID) {
 		UTripOption tripOption = uTripPlanMapper.getTripPlanByUUID(planUUID);
 		if (tripOption != null) {
+			// 실제 회원과 가상 회원 목록 조회
+			List<String> realMembers = uTripPlanMapper.getRealMembersByPlanUUID(planUUID);
+			List<String> virtualMembers = uTripPlanMapper.getVirtualMembersByPlanUUID(planUUID);
+			tripOption.setInvitedMembers(realMembers);
+			tripOption.setVirtualMembers(virtualMembers);
+
 			// TRIP_PLAN_ITEMS_NEW 테이블에서 일정 항목 조회
 			List<UTripPlanItem> tripItems = uTripPlanMapper.getTripItemsByUUID(planUUID);
 			log.info("tripItems: {}", tripItems);
@@ -335,7 +344,12 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 		return null;
 	}
 
-
+	/**
+	 * 각 일자별로 여행 계획 아이템을 설정하는 메서드
+	 * @param tripOption 여행 계획
+	 * @param tripItems 여행 계획 세부 아이템
+	 * @param tourDetailMap 여행지 세부 정보
+	 */
 	private void addTripItemsForDates(UTripOption tripOption, List<UTripPlanItem> tripItems, Map<String, PTourDetail> tourDetailMap) {
 		if (tripOption.getStartDate() == null || tripItems == null || tripItems.isEmpty()) {
 			throw new IllegalArgumentException("Start date and trip items must be provided.");
@@ -387,6 +401,10 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 		}
 	}
 
+	/**
+	 * 수정 날짜와 현재 시간을 duration으로 변환하는 메서드
+	 * @param uTripOption 여행 계획 DTO
+	 */
 	private void calculateAndSetDayDiff(UTripOption uTripOption) {
 		LocalDateTime currentDateTime = LocalDateTime.now();
 
@@ -406,6 +424,11 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 		}
 	}
 
+	/**
+	 * 입력된 dateString을 포맷에 맞게 설정하는 메서드
+	 * @param dateString 일자 형식으로 작성된 String
+	 * @return String을 LocalDateTime으로 변경
+	 */
 	private LocalDateTime parseDateStringToLocalDateTime(String dateString) {
 		// 입력된 dateString의 포맷에 맞게 DateTimeFormatter 생성
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
@@ -414,6 +437,11 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 		return LocalDateTime.parse(dateString, formatter);
 	}
 
+	/**
+	 * 작성된 시간과 현재를 비교해서 년,달,일,시간,분 전으로 표기하는 메서드
+	 * @param duration 과거 날짜와 현재 날짜의 차이
+	 * @return 년,달,일,시간,분 전 으로 표기
+	 */
 	private String calculateDayDiffWord(Duration duration) {
 		long years = duration.toDays() / 365;
 		long months = duration.toDays() / 30;
@@ -437,6 +465,11 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 		return dayDiffWord;
 	}
 
+	/**
+	 * 여행 계획에 참여하는 실제 회원을 조회하고 없다면 삽입하는 메서드
+	 * @param tripUuid 여행 계획 UUID
+	 * @param realMemberIds 실제 회원 아이디 목록
+	 */
 	private void saveRealMembers(String tripUuid, List<String> realMemberIds) {
 		for (String memberId : realMemberIds) {
 			// 실제 멤버가 존재하는지 확인
@@ -451,10 +484,18 @@ public class UTripPlanServiceImpl implements UTripPlanService {
 		}
 	}
 
+	/**
+	 * 여행에 참여하는 가상 회원을 삭제하는 메서드
+	 * @param tripUuid 여행 계획 UUID
+	 */
 	private void deleteVirtualMembers(String tripUuid) {
 		uTripPlanMapper.deleteTripVirtualMembers(tripUuid);
 	}
 
+	/**
+	 * 여행에 참여하는 실제 회원을 삭제하는 메서드
+	 * @param tripUuid 여행 계획 UUID
+	 */
 	private void deleteRealMembers(String tripUuid) {
 		uTripPlanMapper.deleteTripRealMembers(tripUuid);
 	}

--- a/src/main/resources/mapper/platform/trip/PTripPlanMapper.xml
+++ b/src/main/resources/mapper/platform/trip/PTripPlanMapper.xml
@@ -353,8 +353,11 @@
 
     <update id="updateImagePath" parameterType="map">
         /* 여행지 상세 정보에 이미지 링크 추가*/
-        UPDATE TOUR_DETAIL_FROM_API
-        SET tour_detail_first_image_path = #{imagePath}
-        WHERE tour_detail_content_id = #{contentId}
+        UPDATE
+            TOUR_DETAIL_FROM_API
+        SET
+            tour_detail_first_image_path = #{imagePath}
+        WHERE
+            tour_detail_content_id = #{contentId}
     </update>
 </mapper>

--- a/src/main/resources/mapper/user/trip/UTripPlanMapper.xml
+++ b/src/main/resources/mapper/user/trip/UTripPlanMapper.xml
@@ -418,4 +418,34 @@
         </foreach>
     </select>
 
+    <select id="getRealMembersByPlanUUID" resultType="string">
+        SELECT
+            m.MBR_ID
+        FROM
+            real_member r
+        JOIN
+            trip_real_member trm
+        ON
+            r.id = trm.real_member_id
+        JOIN
+            MEMBER_MANAGE m
+        ON
+            r.member_id = m.MBR_ID
+        WHERE
+            trm.trip_uuid = #{planUUID}
+    </select>
+
+    <select id="getVirtualMembersByPlanUUID" resultType="string">
+        SELECT
+            v.name
+        FROM
+            virtual_member v
+        JOIN
+            trip_virtual_member tvm
+        ON
+            v.id = tvm.virtual_member_id
+        WHERE
+            tvm.trip_uuid = #{planUUID}
+    </select>
+
 </mapper>

--- a/src/main/resources/templates/platform/trip/destinationInfoManage.html
+++ b/src/main/resources/templates/platform/trip/destinationInfoManage.html
@@ -17,7 +17,39 @@
             height: 40px;
             padding: 5px;
         }
+        /* 240610 로딩 이미지 추가 */
+        #loading_spinner{
+            display: none;
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            z-index: 99;
+        }
+        .cv_spinner{
+            height: 100%;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            align-content: stretch;
+            justify-content: center;
+            align-items: baseline;
+            position: relative;
+        }
+        .spinner-load {
+            width: 100px;
+            height: 100px;
+            border: 15px #ddd solid;
+            border-top: 15px #2e93e6 solid;
+            border-radius: 50%;
+            animation: sp-anime 0.8s infinite linear;
+        }
+        @keyframes sp-anime {
+            100% {
+                transform: rotate(360deg);
+            }
+        }
     </style>
+
 </th:block>
 
 <th:block layout:fragment="customContent">
@@ -102,7 +134,11 @@
             </div>
         </div>
     </div>
-
+    <div id="loading_spinner">
+        <div class="cv_spinner">
+            <span class="spinner-load"></span>
+        </div>
+    </div>
 </th:block>
 
 <th:block layout:fragment="customJsFile">
@@ -277,38 +313,49 @@
     </script>
     <script th:inline="javascript">
         $(document).on('click', '.data-list-update', function () {
-            const request = $.ajax({
-                url: '/platform/plan/destination/list-update',
-                method: 'POST',
-                dataType: 'text',
-                success: function (response) {
-                    // 성공적으로 응답을 받았을 때 실행할 코드
-                    console.log('결과: ', response);
-                    alert(response);
-                },
-                error: function (xhr, status, error) {
-                    // 오류 발생 시 실행할 코드
-                    alert(xhr.responseText);
-                }
-            });
+            if (confirm("현재 572개의 데이터 전체가 업데이트 되며, 약 5분 정도 소요가 예상됩니다. 진행하시겠습니까?")) {
+                const request = $.ajax({
+                    url: '/platform/plan/destination/list-update',
+                    method: 'POST',
+                    dataType: 'text',
+                    success: function (response) {
+                        // 성공적으로 응답을 받았을 때 실행할 코드
+                        console.log('결과: ', response);
+                        alert(response);
+                    },
+                    error: function (xhr, status, error) {
+                        // 오류 발생 시 실행할 코드
+                        alert(xhr.responseText);
+                    }
+                });
+            }
+
         });
     </script>
     <script th:inline="javascript">
         $(document).on('click', '.image-update', function () {
-            const request = $.ajax({
-                url: '/platform/plan/destination/image-update',
-                method: 'POST',
-                dataType: 'text',
-                success: function (response) {
-                    // 성공적으로 응답을 받았을 때 실행할 코드
-                    console.log('결과: ', response);
-                    alert(response);
-                },
-                error: function (xhr, status, error) {
-                    // 오류 발생 시 실행할 코드
-                    alert(xhr.responseText);
-                }
-            });
+            if (confirm("현재 394개의 데이터 전체가 업데이트 되며, 약 7분 정도 소요가 예상됩니다. 진행하시겠습니까?")) {
+                const request = $.ajax({
+                    url: '/platform/plan/destination/image-update',
+                    method: 'POST',
+                    dataType: 'text',
+                    success: function (response) {
+                        // 성공적으로 응답을 받았을 때 실행할 코드
+                        console.log('결과: ', response);
+                        alert(response);
+                    },
+                    beforeSend: function () {
+                        $('#loading_spinner').show();
+                    },
+                    complete: function () {
+                        $('#loading_spinner').hide();
+                    },
+                    error: function (xhr, status, error) {
+                        // 오류 발생 시 실행할 코드
+                        alert(xhr.responseText);
+                    }
+                });
+            }
         });
     </script>
 </th:block>

--- a/src/main/resources/templates/user/trip/planSchedule.html
+++ b/src/main/resources/templates/user/trip/planSchedule.html
@@ -10,14 +10,29 @@
         <button class="btn btn-primary btn-sm me-2" type="button" id="modifyPlan">수정(구현 안됨)</button>
         <button class="btn btn-secondary btn-sm" id="backToListButton" type="button">목록으로</button>
     </div>
-    <h2 class="text-uppercase text-letter-spacing-xs my-0 text-primary font-weight-bold"
+    <h2 class="text-uppercase text-letter-spacing-xs my-0 text-primary font-weight-bold mb-3"
         th:if="${tripOption != null}" th:text="${tripOption.tripTitle}">Schedule</h2>
-    <h2 class="text-uppercase text-letter-spacing-xs my-0 text-primary font-weight-bold"
+    <h2 class="text-uppercase text-letter-spacing-xs my-0 text-primary font-weight-bold mb-3"
         th:unless="${tripOption != null}">Schedule</h2>
     <p>
         출발 날짜: <span th:text="${tripOption.startDate}">출발 날짜</span>,
         도착 날짜: <span th:text="${tripOption.endDate}">도착 날짜</span>
     </p>
+    <div>
+        <h5>실제 회원:</h5>
+        <ul th:if="${not #lists.isEmpty(tripOption.invitedMembers)}">
+            <li th:each="member : ${tripOption.invitedMembers}" th:text="${member}"></li>
+        </ul>
+        <p th:if="${#lists.isEmpty(tripOption.invitedMembers)}">없음</p>
+    </div>
+
+    <div>
+        <h5>가상 회원:</h5>
+        <ul th:if="${not #lists.isEmpty(tripOption.virtualMembers)}">
+            <li th:each="member : ${tripOption.virtualMembers}" th:text="${member}"></li>
+        </ul>
+        <p th:if="${#lists.isEmpty(tripOption.virtualMembers)}">없음</p>
+    </div>
     <!-- Days -->
     <div class="row mt-7">
         <div th:if="${tripOption != null}" th:each="dayPlan, dayStat : ${tripOption.dayPlans}" class="col-lg-6 mb-3" th:id="'day-' + ${dayStat.index}">


### PR DESCRIPTION
DETAIL: 
240610 18:01
외부 파일 경로 설정,
일자별로 여행 상세 정보 정렬 및 페이지 출력,
실제회원, 가상회원 목록 출력

DestinationService
DestinationMapper
타입 수정

EDIT: 
destinationInfoManage.html
planSchedule.html
PTripPlanMapper.xml
PTripPlanServiceImpl.java
UTripPlanMapper.java
UTripPlanMapper.xml
UTripPlanServiceImpl.java
WebConfig.java

CRETE:
platform\trip\config\TripWebConfig.java

TO DO:

세부 아이템 페이지에서 저장 버튼을 누르면 DB에 저장,
내 계획 목록에서 각 계획을 조회하면 스케줄 형식으로 보이도록 표시,
수정 버튼을 누르면 현재 작성 페이지에 관련 값들이 다 들어온 상태로 오도록 표시,
내 계획 목록이나 조회 페이지에서 공유 버튼을 누르면 게시판으로 작성해 정보를 가져오는 페이지 작성