### PR TITLE
Bit

### DIFF
--- a/src/main/java/ksmart/ks50team01/documentation/controller/DocumentController.java
+++ b/src/main/java/ksmart/ks50team01/documentation/controller/DocumentController.java
@@ -85,8 +85,9 @@ public class DocumentController {
 	@ResponseBody
 	public ResponseEntity<DocumentApiResponse> updateDocuments() {
 		try {
-			documentService.processDocumentUpdate();
-			return ResponseEntity.ok(DocumentApiResponse.success("문서가 성공적으로 업데이트되었습니다."));
+			// 서비스의 처리 결과를 받아서 그대로 반환
+			DocumentApiResponse response = documentService.processDocumentUpdate();
+			return ResponseEntity.ok(response);
 		} catch (Exception e) {
 			log.error("문서 업데이트 중 오류 발생", e);
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/ksmart/ks50team01/documentation/service/impl/DocumentServiceImpl.java
+++ b/src/main/java/ksmart/ks50team01/documentation/service/impl/DocumentServiceImpl.java
@@ -104,7 +104,7 @@ public class DocumentServiceImpl implements DocumentService {
 		if (existingDocument == null) {
 			// 새로운 문서인 경우 저장
 			saveNewDocument(processResult);
-			return DocumentApiResponse.success("문서가 성공적으로 업데이트되었습니다.");
+			return DocumentApiResponse.success("새로운 문서가 감지되어 업데이트를 진행했습니다.");
 		} else {
 			// 이미 존재하는 문서인 경우
 			log.info("동일한 해시값의 문서가 이미 존재합니다: {}", processResult.getFileHash());

--- a/src/main/resources/static/documentation/js/common.js
+++ b/src/main/resources/static/documentation/js/common.js
@@ -77,7 +77,10 @@ const DocumentManager = (function() {
                 success: (response) => {
                     if (response.status === 'success') {
                         this.showAlert('success', response.message);
-                        setTimeout(() => location.reload(), 1500);
+                        // 새로운 문서가 업데이트된 경우에만 페이지 새로고침
+                        if (response.message.includes('새로운 문서')) {
+                            setTimeout(() => location.reload(), 1500);
+                        }
                     } else {
                         this.showAlert('danger', response.message);
                     }


### PR DESCRIPTION
fix: 파일 다운로드 경로 처리 및 문자 검증 수정

- 문서 다운로드 시 상위 디렉토리 경로가 누락되는 문제 수정
- 파일 경로의 특수문자 및 한글 처리를 위한 정규식 패턴 수정
- DirectoryTreeUtil에서 전체 상대 경로를 포함하도록 수정

Details:
- DocumentController의 파일 경로 검증 정규식 수정 (한글, 공백, 특수문자 허용)
- validateFilePath 메서드의 경로 검증 로직 개선
- 상위 디렉토리를 포함한 전체 상대 경로 생성 로직 추가